### PR TITLE
feat: Enhance player filtering with allowlist support and wildcard matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,8 @@ Keep in mind that when using XDG Autostart, there's no built-in way to restart t
 
 To select the music players, use the `-a`,`--allowlist-add` argument or `allowlist` in the config file. This argument can be used multiple times to add more players. The order matters and the first is the most important.
 
+You can filter by player name (identity) or by MPRIS bus name. This is useful when multiple players have the same identity.
+
 arguments:
 
 ```sh
@@ -325,7 +327,36 @@ allowlist:
   - "Any other player"
 ```
 
-Use the `-l`, `--list-players` to get your player name.
+Use the `-l`, `--list-players` to get your player name and bus name.
+
+If you have multiple players with the same name (e.g., browser with both native MPRIS and browser extension), you can use the bus name to distinguish them:
+
+```yaml
+allowlist:
+  - "org.mpris.MediaPlayer2.plasma-browser-integration"
+```
+
+or with arguments:
+
+```sh
+music-discord-rpc -a "org.mpris.MediaPlayer2.plasma-browser-integration"
+```
+
+You can also use wildcards (`*`) at the end of patterns to match players with dynamic bus names (e.g., KDE Connect devices or browser instances):
+
+```yaml
+allowlist:
+  - "org.mpris.MediaPlayer2.kdeconnect.mpris_*"
+  - "org.mpris.MediaPlayer2.brave.instance*"
+```
+
+or with arguments:
+
+```sh
+music-discord-rpc -a "org.mpris.MediaPlayer2.kdeconnect.mpris_*"
+```
+
+Note: Only suffix wildcards are supported (pattern must end with `*`). Wildcards in the middle or at the beginning are not supported.
 
 ### "Watching Video" activity
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -192,10 +192,11 @@ disable_mpris_art_url: false
 # Only use the status from the following music players
 # Use -l, --list-players to get player exact name to use with this option
 # The order matters and the first is the most important.
+# You can use wildcard (*) at the end of a pattern to match any player name starting with that prefix.
 # allowlist:
 #   - "VLC Media Player"
 #   - "Chrome"
-#   - "Any other player"
+#   - "org.mpris.MediaPlayer2.kdeconnect.mpris_*"
 
 # Will use the "watching" activity
 # Use -l, --list-players to get player exact name to use with this option


### PR DESCRIPTION
  Fix deterministic player selection and add smart priority-based filtering

  This PR resolves multiple issues related to player selection when multiple
   MPRIS players have the same identity name.

  Problem

  When multiple players share the same name (e.g., multiple Brave browser
  instances), the application would randomly select between them, leading
  to:
  - Inconsistent player selection on startup
  - Status showing the wrong player's metadata
  - The app "sticking" to a paused player instead of switching to one that's
   actively playing

  Example scenario:
   * Brave (org.mpris.MediaPlayer2.brave.instance123)
   * YouTube - Galaxy (org.mpris.MediaPlayer2.kdeconnect.mpris_)
   * Brave (org.mpris.MediaPlayer2.plasma-browser-integration)

  In the above case, both Brave entries have identical identity names but
  different bus names. Previously, the app would pick one
  non-deterministically.

  Solution

  This PR implements smart priority-based player selection with the
  following improvements:

  1. Deterministic Selection Algorithm

  Players are now selected based on a priority tuple:
  (playback_status, allowlist_position, metadata_quality, bus_name)

  - Playback status: Playing (0) > Paused (1) > Stopped/Unknown (2)
  - Allowlist position: Earlier in allowlist = higher priority
  - Metadata quality: Valid metadata (has title + artist) preferred
  - Bus name: Lexicographic ordering as final tiebreaker (ensures
  deterministic selection)

  This means the app will consistently prefer:
  - Playing players over paused ones
  - Players listed earlier in the allowlist
  - Players with complete metadata
  - When all else is equal, the same player every time (via bus name
  ordering)

  2. Wildcard Pattern Support

  The allowlist now supports suffix wildcards (*) for matching multiple
  instances:

  allowlist:
    - "Brave*"  # Matches any Brave instance
    - "org.mpris.MediaPlayer2.kdeconnect.mpris_*"  # Matches KDE Connect 
  players
    - "Spotify"  # Exact match (no wildcard)

  Pattern matching works on both:
  - Player identity (e.g., "Brave")
  - MPRIS bus name (e.g., "org.mpris.MediaPlayer2.brave.instance123")

  3. Enhanced Debug Logging

  Added bus name to Loop 1 debug output:
  [debug] player_name: Brave
  [debug] player_bus_name: org.mpris.MediaPlayer2.brave.instance123
  [debug] player_id: brave

  This makes it easier to diagnose which exact player instance is being
  selected.

  Impact on Issue #44

  This PR may partially resolve #44 (multiple player handling). The new
  priority-based selection automatically switches to playing players when
  the current player is paused, addressing the core complaint that "the
  program checks the allow list before verifying actual playback state."

  However, note that:
  - This doesn't add continuous monitoring of all players (still uses single
   active player model)
  - Manual switching between paused players still requires the app to detect
   the previous player closed
  - Full "multi-player mode" would require architectural changes beyond this
   PR's scope

  Changes

  Core Implementation:
  - Added helper functions: matches_allowlist(), is_player_allowlisted(),
  get_playback_priority(), has_valid_metadata()
  - Rewrote player selection logic with priority tuple sorting
  - Implemented wildcard pattern matching with strip_suffix('*')